### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2690,8 +2690,8 @@
             }
         },
         "jquery": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
             "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
         },
         "jsonfile": {


### PR DESCRIPTION
CVE ID : CVE-2019-11358
More information : moderate severity
Vulnerable versions: < 3.4.0
Patched version: 3.4.0

jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution. If an unsanitized source object contained an enumerable proto property, it could extend the native Object.prototype.